### PR TITLE
Cmake build for ACCESS3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ endif()
 
 if(NOT TARGET NetCDF::NetCDF_Fortran) #Access3Share probably already has NetCDF with PUBLIC interface
   find_package(NetCDF 4.7.3 MODULE REQUIRED Fortran)
+  # Code has not been tested with versions older than 4.7.3, but probably still works fine
 endif()
 
 if(WW3_OPENMP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,8 +91,8 @@ if(ACCESS3_WW3)
   find_package(ESMF 8.3.0 MODULE REQUIRED)
 endif()
 
-find_package(NetCDF 4.7.3 REQUIRED Fortran)
-
+# find_package(NetCDF 4.7.3 REQUIRED Fortran)
+find_package(MPI REQUIRED)
 
 #[==============================================================================[
 #                             Main definitions                                  #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,8 @@ project(WW3
 #]==============================================================================]
 
 ## List of switches
+# to-do: make configurable 
 list(APPEND switches "CESMCOUPLED" "DIST" "MPI" "PR1" "FLX4" "ST6" "STAB0" "LN1" "NL1" "BT1" "DB1" "MLIM" "TR0" "BS0" "RWND" "WNX1" "WNT0" "CRX1" "CRT0" "O0" "O1" "O2" "O3" "O4" "O5" "O6" "O7" "O14" "O15" "IS2" "REF0" "NOGRB" "IC3")
-
-## Global compile definitions
-foreach(switch ${switches})
-  add_compile_definitions(W3_${switch})
-endforeach()
 
 option(ACCESS3_WW3     "Use ACCESS3 dependencies and install ACCESS3 libraries" OFF)
 option(OPENMP          "Enable OpenMP threading" OFF)
@@ -30,21 +26,22 @@ if(NOT ACCESS3_WW3)
   message(STATUS " - NOT ACCESS3_WW3: Building standalone ww3_shel for testing")
 endif()
 
-if(ACCESS3_WW3)
-  option(CESMCOUPLED           "CESMCOUPLED Build CPP" OFF)
-  message(STATUS "  - CESMCOUPLED   ${CESMCOUPLED}")
-endif()
-
 if(OPENMP)
   list(APPEND switches "OMPG")
 endif()
+
+set(NETCDF ON CACHE BOOL "Build NetCDF programs (requires NetCDF)")
+set(ENDIAN "BIG" CACHE STRING "Endianness of unformatted output files. Valid values are 'BIG', 'LITTLE', 'NATIVE'.") 
 
 
 #[==============================================================================[
 #                           Project configuration                               #
 #]==============================================================================]
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+
+
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 include(FortranLib)
@@ -77,11 +74,13 @@ else()
   message(WARNING "C compiler with ID ${CMAKE_C_COMPILER_ID} will be used with CMake default options")
 endif()
 
-if (CESMCOUPLED)
-  add_compile_definitions(
-    CESMCOUPLED
-    W3_CESMCOUPLED
-  )
+## Global compile definitions
+foreach(switch ${switches})
+  add_compile_definitions(W3_${switch})
+endforeach()
+
+if ("CESMCOUPLED" IN_LIST switches)
+  add_compile_definitions(CESMCOUPLED)
 endif()
 
 ## Fortran modules path; currently this is simply set to be the include dir
@@ -144,15 +143,11 @@ endif()
 
 list(APPEND ftn_src ${switch_files})
 
-foreach(file ${ftn_src} )
+foreach(file ${ftn_src})
     list(APPEND srcfiles "${CMAKE_CURRENT_SOURCE_DIR}/model/src/${file}")
 endforeach()
 
-target_sources(ww3lib PRIVATE
-  ${srcfiles}
-)
-
-
+target_sources(ww3lib PRIVATE ${srcfiles}) 
 
 ## Utilities
 # Always build utilities:
@@ -180,8 +175,9 @@ target_sources(ww3_ounf PRIVATE
   ${SRC}/w3ounfmetamd.F90
 )
 
-
-### Install and Export
+#[==============================================================================[
+#                             Install and Export                                  #
+#]==============================================================================]
 
 ## Library
 if(ACCESS3_WW3)
@@ -222,10 +218,6 @@ if(ACCESS3_WW3)
 endif()
 
 ## Utilities
-<<<<<<< HEAD
 install(TARGETS ${utility_apps}
 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-=======
-install(TARGETS ww3_grid ww3_strt ww3_outf ww3_ounf ww3_ounp
-RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
->>>>>>> origin/1-cmake_build
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,68 +1,223 @@
-# CMake build written by Kyle Gerheiser
-
-# Requires CMake 3.19 for JSON strings
 cmake_minimum_required(VERSION 3.19)
 
-# Get VERSION from VERSION file
-file(STRINGS "VERSION" pVersion)
+#[==============================================================================[
+#                         Basic project definition                              #
+#]==============================================================================]
 
-project(
-  WW3
-  VERSION ${pVersion}
-  LANGUAGES C Fortran)
+project(WW3
+        DESCRIPTION "WAVEWATCH III numerical wave model"
+        HOMEPAGE_URL https://github.com/ACCESS-NRI/WW3/
+        LANGUAGES C Fortran)
 
-get_directory_property(hasParent PARENT_DIRECTORY)
-if(hasParent)
-  # Unset flags that come from Parent (ie UFS or other coupled build) 
-  # for potential (-r8/-r4) conflict
-  set(CMAKE_Fortran_FLAGS "")
-  set(CMAKE_C_FLAGS "")
-  remove_definitions(-DDEBUG)
+#[==============================================================================[
+#                                   Options                                     #
+#]==============================================================================]
+
+## List of switches
+list(APPEND switches "CESMCOUPLED" "DIST" "MPI" "PR1" "FLX4" "ST6" "STAB0" "LN1" "NL1" "BT1" "DB1" "MLIM" "TR0" "BS0" "RWND" "WNX1" "WNT0" "CRX1" "CRT0" "O0" "O1" "O2" "O3" "O4" "O5" "O6" "O7" "O14" "O15" "IS2" "REF0" "NOGRB" "IC3")
+
+## Global compile definitions
+foreach(switch ${switches})
+  add_compile_definitions(W3_${switch})
+endforeach()
+
+option(ACCESS3_WW3          "Use ACCESS3 dependencies and install ACCESS3 libraries" OFF)
+message(STATUS "  - ACCESS3_WW3   ${ACCESS3_WW3}")
+
+if(NOT ACCESS3_WW3)
+  message(FATAL_ERROR " ACCESS3_WW3 is only supported build, set to ON")
 endif()
 
-set(valid_caps "MULTI_ESMF" "NUOPC_MESH")
+if(ACCESS3_WW3)
+  option(CESMCOUPLED           "CESMCOUPLED Build CPP" OFF)
+  message(STATUS "  - CESMCOUPLED   ${CESMCOUPLED}")
+endif()
 
-set(UFS_CAP "" CACHE STRING "Valid options are ${valid_caps}")
-set(NETCDF ON CACHE BOOL "Build NetCDF programs (requires NetCDF)")
-set(ENDIAN "BIG" CACHE STRING "Endianness of unformatted output files. Valid values are 'BIG', 'LITTLE', 'NATIVE'.") 
-set(EXCLUDE_FIND "" CACHE STRING "Don't try and search for these libraries (assumd to be handled by the compiler/wrapper)")
+#[==============================================================================[
+#                           Project configuration                               #
+#]==============================================================================]
 
-# make sure all "exclude_find" entries are lower case
-list(TRANSFORM EXCLUDE_FIND TOLOWER)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+include(FortranLib)
 
-# Make Find modules visible to CMake
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-
-# Set switch file on command line when running CMake
-set(SWITCH "" CACHE STRING "Switch file, either full path, relative path from location of top-level WW3/ dir, or a switch in model/bin")
-
-# Search for switch file as a full path or in model/bin
-if(EXISTS ${SWITCH})
-  set(switch_file ${SWITCH})
+# Common compiler flags and definitions
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fbacktrace -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none")
+  if(${CMAKE_Fortran_COMPILER_VERSION} VERSION_GREATER_EQUAL 10)
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-argument-mismatch")
+  endif()
+  set(CMAKE_Fortran_FLAGS_RELEASE "-O")
+  set(CMAKE_Fortran_FLAGS_DEBUG "-g -Wall -Og -ffpe-trap=zero,overflow -fcheck=bounds")
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qno-opt-dynamic-align  -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model precise")
+  set(CMAKE_Fortran_FLAGS_RELEASE "-O2 -debug minimal")
+  set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created")
 else()
-  set(switch_file ${CMAKE_CURRENT_SOURCE_DIR}/model/bin/switch_${SWITCH})
-  if(NOT EXISTS ${switch_file})
-    message(FATAL_ERROR "Switch file '${switch_file}' does not exist, set switch with -DSWITCH=<switch>")
-  endif()
+  message(WARNING "Fortran compiler with ID ${CMAKE_Fortran_COMPILER_ID} will be used with CMake default options")
 endif()
 
-if(UFS_CAP)
-  if(NOT UFS_CAP IN_LIST valid_caps)
-    message(FATAL_ERROR "Invalid UFS_CAP selection. Valids options are ${valid_caps}")
-  endif()
+if(CMAKE_C_COMPILER_ID MATCHES "GNU")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
+  set(CMAKE_C_FLAGS_RELEASE "-O")
+  set(CMAKE_C_FLAGS_DEBUG "-g -Wall -Og -fbacktrace -ffpe-trap=invalid,zero,overflow -fcheck=bounds")
+elseif(CMAKE_C_COMPILER_ID MATCHES "Intel")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -traceback -qno-opt-dynamic-align -fp-model precise -std=gnu99")
+  set(CMAKE_C_FLAGS_RELEASE "-O2 -debug minimal")
+  set(CMAKE_C_FLAGS_DEBUG "-O0 -g")
+else()
+  message(WARNING "C compiler with ID ${CMAKE_C_COMPILER_ID} will be used with CMake default options")
 endif()
 
-message(STATUS "Build with switch: ${switch_file}")
-# Copy switch file to build dir
-configure_file(${switch_file} ${CMAKE_BINARY_DIR}/switch COPYONLY)
-
-# Re-configure CMake when switch changes
-set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${CMAKE_BINARY_DIR}/switch)
-
-if(NOT CMAKE_BUILD_TYPE MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel)$")
-  message(STATUS "Setting build type to 'Release' as none was specified.")
-  set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type" FORCE)
-  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+if (CESMCOUPLED)
+  add_compile_definitions(
+    CESMCOUPLED
+  )
 endif()
 
-add_subdirectory(model)
+## Fortran modules path; currently this is simply set to be the include dir
+set(CMAKE_INSTALL_MODULEDIR ${CMAKE_INSTALL_INCLUDEDIR}
+  CACHE STRING
+  "Fortran module installation path (Not a cmake native variable)"
+)
+
+#[==============================================================================[
+#                              External packages                                #
+#]==============================================================================]
+
+if(ACCESS3_WW3)
+  find_package(Access3Share REQUIRED cdeps timing share nuopc_cap_share) 
+  find_package(ESMF 8.3.0 MODULE REQUIRED)
+endif()
+
+find_package(NetCDF 4.7.3 REQUIRED Fortran)
+
+
+#[==============================================================================[
+#                             Main definitions                                  #
+#]==============================================================================]
+
+## WW3 library
+
+set(SRC "${CMAKE_SOURCE_DIR}/model/src")
+
+add_fortran_library(ww3lib mod STATIC)
+target_include_directories(ww3lib PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/model/src>)
+target_compile_definitions(ww3lib PRIVATE ENDIANNESS="big_endian")
+set_property(SOURCE ${SRC}/w3initmd.F90
+  APPEND
+  PROPERTY COMPILE_DEFINITIONS
+  "__WW3_SWITCHES__=\'\'"
+)
+target_link_libraries(ww3lib
+  PUBLIC esmf
+)
+# Process switches and get list of extra source files
+include(${CMAKE_CURRENT_SOURCE_DIR}/model/src/cmake/check_switches.cmake)
+check_switches("${switches}" switch_files)
+message(VERBOSE "WW3 switch files: ${switch_files}")
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/model/src/cmake/src_list.cmake)
+list(APPEND ftn_src ${nuopc_mesh_cap_src})
+
+list(APPEND ftn_src ${switch_files})
+
+foreach(file ${ftn_src} )
+    # list(REMOVE_ITEM srcfiles ${file})
+    list(APPEND srcfiles "${CMAKE_CURRENT_SOURCE_DIR}/model/src/${file}")
+endforeach()
+
+target_sources(ww3lib PRIVATE
+  ${srcfiles}
+)
+
+## Utilities
+
+# ww3_grid
+add_executable(ww3_grid ${SRC}/ww3_grid.F90)
+set_target_properties(ww3_grid PROPERTIES
+  LINKER_LANGUAGE Fortran
+  OUTPUT_NAME ww3_grid
+)
+target_link_libraries(ww3_grid PRIVATE ww3lib)
+
+# ww3_strt
+add_executable(ww3_strt ${SRC}/ww3_strt.F90)
+set_target_properties(ww3_strt PROPERTIES
+  LINKER_LANGUAGE Fortran
+  OUTPUT_NAME ww3_strt
+)
+target_link_libraries(ww3_strt PRIVATE ww3lib)
+
+# ww3_outf
+add_executable(ww3_outf ${SRC}/ww3_outf.F90)
+set_target_properties(ww3_outf PROPERTIES
+  LINKER_LANGUAGE Fortran
+  OUTPUT_NAME ww3_outf
+)
+target_link_libraries(ww3_outf PRIVATE ww3lib)
+
+# ww3_ounf
+add_executable(ww3_ounf)
+target_sources(ww3_ounf PRIVATE
+  ${SRC}/ww3_ounf.F90
+  ${SRC}/w3ounfmetamd.F90
+)
+set_target_properties(ww3_ounf PROPERTIES
+  LINKER_LANGUAGE Fortran
+  OUTPUT_NAME ww3_ounf
+)
+target_link_libraries(ww3_ounf PRIVATE ww3lib)
+
+# ww3_ounp
+add_executable(ww3_ounp ${SRC}/ww3_ounp.F90)
+set_target_properties(ww3_ounp PROPERTIES
+  LINKER_LANGUAGE Fortran
+  OUTPUT_NAME ww3_ounp
+)
+target_link_libraries(ww3_ounp PRIVATE ww3lib)
+
+### Install and Export
+
+## Library
+if(ACCESS3_WW3)
+  set_target_properties(ww3lib PROPERTIES
+    OUTPUT_NAME access-ww3lib
+    EXPORT_NAME ww3lib
+  )
+  install(TARGETS ww3lib
+    EXPORT Ww3libTargets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessWW3Cmeps_RunTime NAMELINK_COMPONENT AccessWW3Cmeps_Development
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessWW3Cmeps_Development
+  )
+  # Fortran module files are a special case, as currently there is no standard
+  # way of handling them in CMake
+  target_include_directories(ww3lib PUBLIC "$<INSTALL_INTERFACE:${CMAKE_INSTALL_MODULEDIR}/access-ww3>")
+  get_target_property(ww3_moddir ww3lib Fortran_MODULE_DIRECTORY)
+  install(FILES ${ww3_moddir}/wav_comp_nuopc.mod
+    DESTINATION ${CMAKE_INSTALL_MODULEDIR}/access-ww3
+    COMPONENT AccessWW3Cmeps_Development
+  )
+  install(EXPORT Ww3libTargets
+    FILE Ww3libTargets.cmake
+    NAMESPACE Access3::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Ww3lib
+  )
+
+  # Make sure the dependencies get exported too
+  configure_package_config_file(
+    cmake/Access3Ww3libConfig.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/Ww3libConfig.cmake"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Ww3lib
+  )
+    
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Ww3libConfig.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Ww3lib
+    COMPONENT AccessWW3Cmeps_Development 
+  )
+endif()
+
+## Utilities
+install(TARGETS ww3_grid ww3_strt ww3_outf ww3_ounf ww3_ounp
+RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,16 +91,17 @@ set(CMAKE_INSTALL_MODULEDIR ${CMAKE_INSTALL_INCLUDEDIR}
 #                              External packages                                #
 #]==============================================================================]
 
-find_package(NetCDF 4.7.3 MODULE REQUIRED Fortran)
 find_package(MPI REQUIRED)
 
 if(ACCESS3_WW3)
   find_package(Access3Share REQUIRED cdeps timing share nuopc_cap_share) 
-  find_package(ESMF 8.3.0 MODULE REQUIRED)
-  # ESMF doesn't come linked to PIO library:
-  if (NOT TARGET PIO::PIO_C)
-    find_package(PIO 2.5.3 REQUIRED COMPONENTS C)
-  endif()
+  if(NOT TARGET ESMF::ESMF) #Access3Share probably already has ESMF with PUBLIC interface
+    find_package(ESMF 8.3.0 MODULE REQUIRED)
+  endif() 
+endif()
+
+if(NOT TARGET NetCDF::NetCDF_Fortran) #Access3Share probably already has NetCDF with PUBLIC interface
+  find_package(NetCDF 4.7.3 MODULE REQUIRED Fortran)
 endif()
 
 if(OPENMP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,10 @@ find_package(MPI REQUIRED)
 if(ACCESS3_WW3)
   find_package(Access3Share REQUIRED cdeps timing share nuopc_cap_share) 
   find_package(ESMF 8.3.0 MODULE REQUIRED)
+  # ESMF doesn't come linked to PIO library:
+  if (NOT TARGET PIO::PIO_C)
+    find_package(PIO 2.5.3 REQUIRED COMPONENTS C)
+  endif()
 endif()
 
 if(OPENMP)
@@ -122,7 +126,7 @@ set_property(SOURCE ${SRC}/w3initmd.F90
 target_link_libraries(ww3lib PUBLIC NetCDF::NetCDF_Fortran)
 
 if(ACCESS3_WW3)
-  target_link_libraries(ww3lib PUBLIC esmf)
+  target_link_libraries(ww3lib PUBLIC ESMF::ESMF PIO::PIO_C)
 endif()
 
 if(OpenMP_Fortran_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ set(CMAKE_INSTALL_MODULEDIR ${CMAKE_INSTALL_INCLUDEDIR}
 #]==============================================================================]
 
 find_package(NetCDF 4.7.3 MODULE REQUIRED Fortran)
+find_package(MPI REQUIRED)
 
 if(ACCESS3_WW3)
   find_package(Access3Share REQUIRED cdeps timing share nuopc_cap_share) 
@@ -208,7 +209,6 @@ if(ACCESS3_WW3)
     "${CMAKE_CURRENT_BINARY_DIR}/Ww3libConfig.cmake"
     INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Ww3lib
   )
-    
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Ww3libConfig.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Ww3lib
     COMPONENT AccessWW3Cmeps_Development 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,17 +21,24 @@ foreach(switch ${switches})
   add_compile_definitions(W3_${switch})
 endforeach()
 
-option(ACCESS3_WW3          "Use ACCESS3 dependencies and install ACCESS3 libraries" OFF)
+option(ACCESS3_WW3     "Use ACCESS3 dependencies and install ACCESS3 libraries" OFF)
+option(OPENMP          "Enable OpenMP threading" OFF)
 message(STATUS "  - ACCESS3_WW3   ${ACCESS3_WW3}")
+message(STATUS "  - OPENMP        ${OPENMP}")
 
 if(NOT ACCESS3_WW3)
-  message(FATAL_ERROR " ACCESS3_WW3 is only supported build, set to ON")
+  message(STATUS " - NOT ACCESS3_WW3: Building standalone ww3_shel for testing")
 endif()
 
 if(ACCESS3_WW3)
   option(CESMCOUPLED           "CESMCOUPLED Build CPP" OFF)
   message(STATUS "  - CESMCOUPLED   ${CESMCOUPLED}")
 endif()
+
+if(OPENMP)
+  list(APPEND switches "OMPG")
+endif()
+
 
 #[==============================================================================[
 #                           Project configuration                               #
@@ -73,6 +80,7 @@ endif()
 if (CESMCOUPLED)
   add_compile_definitions(
     CESMCOUPLED
+    W3_CESMCOUPLED
   )
 endif()
 
@@ -86,13 +94,16 @@ set(CMAKE_INSTALL_MODULEDIR ${CMAKE_INSTALL_INCLUDEDIR}
 #                              External packages                                #
 #]==============================================================================]
 
+find_package(NetCDF 4.7.3 MODULE REQUIRED Fortran)
+
 if(ACCESS3_WW3)
   find_package(Access3Share REQUIRED cdeps timing share nuopc_cap_share) 
   find_package(ESMF 8.3.0 MODULE REQUIRED)
 endif()
 
-find_package(NetCDF 4.7.3 REQUIRED Fortran)
-
+if(OPENMP)
+  find_package(OpenMP REQUIRED COMPONENTS Fortran)
+endif()
 
 #[==============================================================================[
 #                             Main definitions                                  #
@@ -110,21 +121,30 @@ set_property(SOURCE ${SRC}/w3initmd.F90
   PROPERTY COMPILE_DEFINITIONS
   "__WW3_SWITCHES__=\'\'"
 )
-target_link_libraries(ww3lib
-  PUBLIC esmf
-)
+target_link_libraries(ww3lib PUBLIC NetCDF::NetCDF_Fortran)
+
+if(ACCESS3_WW3)
+  target_link_libraries(ww3lib PUBLIC esmf)
+endif()
+
+if(OpenMP_Fortran_FOUND)
+  target_link_libraries(ww3lib PUBLIC OpenMP::OpenMP_Fortran)
+endif()
+
 # Process switches and get list of extra source files
 include(${CMAKE_CURRENT_SOURCE_DIR}/model/src/cmake/check_switches.cmake)
 check_switches("${switches}" switch_files)
 message(VERBOSE "WW3 switch files: ${switch_files}")
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/model/src/cmake/src_list.cmake)
-list(APPEND ftn_src ${nuopc_mesh_cap_src})
+
+if(ACCESS3_WW3)
+  list(APPEND ftn_src ${nuopc_mesh_cap_src})
+endif()
 
 list(APPEND ftn_src ${switch_files})
 
 foreach(file ${ftn_src} )
-    # list(REMOVE_ITEM srcfiles ${file})
     list(APPEND srcfiles "${CMAKE_CURRENT_SOURCE_DIR}/model/src/${file}")
 endforeach()
 
@@ -132,51 +152,34 @@ target_sources(ww3lib PRIVATE
   ${srcfiles}
 )
 
+
+
 ## Utilities
+# Always build utilities:
+set(utility_apps ww3_grid ww3_strt ww3_outf ww3_ounf ww3_ounp)
+if(NOT ACCESS3_WW3)
+  # A generic WW3 "shell" for testing
+  list(APPEND utility_apps ww3_shel)
+endif()
+  #to-do: confim when other utilities are needed:
+  # ww3_bound ww3_outp ww3_trck ww3_grib
+  # ww3_gint gx_outf gx_outp ww3_uprstr ww3_prep ww3_gspl ww3_multi ww3_systrk
+  # ww3_ounf ww3_ounp ww3_bounc ww3_trnc ww3_prnc
 
-# ww3_grid
-add_executable(ww3_grid ${SRC}/ww3_grid.F90)
-set_target_properties(ww3_grid PROPERTIES
-  LINKER_LANGUAGE Fortran
-  OUTPUT_NAME ww3_grid
-)
-target_link_libraries(ww3_grid PRIVATE ww3lib)
+foreach(program ${utility_apps})
+  add_executable(${program} ${SRC}/${program}.F90)
+  set_target_properties(${program} PROPERTIES
+    LINKER_LANGUAGE Fortran
+    OUTPUT_NAME ${program}
+  )
+  target_link_libraries(${program} PRIVATE ww3lib)
+endforeach()
 
-# ww3_strt
-add_executable(ww3_strt ${SRC}/ww3_strt.F90)
-set_target_properties(ww3_strt PROPERTIES
-  LINKER_LANGUAGE Fortran
-  OUTPUT_NAME ww3_strt
-)
-target_link_libraries(ww3_strt PRIVATE ww3lib)
-
-# ww3_outf
-add_executable(ww3_outf ${SRC}/ww3_outf.F90)
-set_target_properties(ww3_outf PROPERTIES
-  LINKER_LANGUAGE Fortran
-  OUTPUT_NAME ww3_outf
-)
-target_link_libraries(ww3_outf PRIVATE ww3lib)
-
-# ww3_ounf
-add_executable(ww3_ounf)
+# ww3_ounf has en extra file
 target_sources(ww3_ounf PRIVATE
-  ${SRC}/ww3_ounf.F90
   ${SRC}/w3ounfmetamd.F90
 )
-set_target_properties(ww3_ounf PROPERTIES
-  LINKER_LANGUAGE Fortran
-  OUTPUT_NAME ww3_ounf
-)
-target_link_libraries(ww3_ounf PRIVATE ww3lib)
 
-# ww3_ounp
-add_executable(ww3_ounp ${SRC}/ww3_ounp.F90)
-set_target_properties(ww3_ounp PROPERTIES
-  LINKER_LANGUAGE Fortran
-  OUTPUT_NAME ww3_ounp
-)
-target_link_libraries(ww3_ounp PRIVATE ww3lib)
 
 ### Install and Export
 
@@ -219,5 +222,5 @@ if(ACCESS3_WW3)
 endif()
 
 ## Utilities
-install(TARGETS ww3_grid ww3_strt ww3_outf ww3_ounf ww3_ounp
+install(TARGETS ${utility_apps}
 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+# Copyright ACCESS-NRI and contributors. See the top-level LICENSE file for details.
+
 cmake_minimum_required(VERSION 3.19)
 
 #[==============================================================================[
@@ -37,8 +39,6 @@ endif()
 #]==============================================================================]
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-
-
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,6 @@ if(OPENMP)
   list(APPEND switches "OMPG")
 endif()
 
-set(NETCDF ON CACHE BOOL "Build NetCDF programs (requires NetCDF)")
-set(ENDIAN "BIG" CACHE STRING "Endianness of unformatted output files. Valid values are 'BIG', 'LITTLE', 'NATIVE'.") 
 
 
 #[==============================================================================[

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,16 +19,16 @@ project(WW3
 # to-do: make configurable 
 list(APPEND switches "CESMCOUPLED" "DIST" "MPI" "PR1" "FLX4" "ST6" "STAB0" "LN1" "NL1" "BT1" "DB1" "MLIM" "TR0" "BS0" "RWND" "WNX1" "WNT0" "CRX1" "CRT0" "O0" "O1" "O2" "O3" "O4" "O5" "O6" "O7" "O14" "O15" "IS2" "REF0" "NOGRB" "IC3")
 
-option(ACCESS3_WW3     "Use ACCESS3 dependencies and install ACCESS3 libraries" OFF)
-option(OPENMP          "Enable OpenMP threading" OFF)
-message(STATUS "  - ACCESS3_WW3   ${ACCESS3_WW3}")
-message(STATUS "  - OPENMP        ${OPENMP}")
+option(WW3_ACCESS3     "Use ACCESS3 dependencies and install ACCESS3 libraries" OFF)
+option(WW3_OPENMP          "Enable OpenMP threading" OFF)
+message(STATUS "  - WW3_ACCESS3   ${WW3_ACCESS3}")
+message(STATUS "  - WW3_OPENMP        ${WW3_OPENMP}")
 
-if(NOT ACCESS3_WW3)
-  message(STATUS " - NOT ACCESS3_WW3: Building standalone ww3_shel for testing")
+if(NOT WW3_ACCESS3)
+  message(STATUS " - NOT WW3_ACCESS3: Building standalone ww3_shel for testing")
 endif()
 
-if(OPENMP)
+if(WW3_OPENMP)
   list(APPEND switches "OMPG")
 endif()
 
@@ -93,7 +93,7 @@ set(CMAKE_INSTALL_MODULEDIR ${CMAKE_INSTALL_INCLUDEDIR}
 
 find_package(MPI REQUIRED)
 
-if(ACCESS3_WW3)
+if(WW3_ACCESS3)
   find_package(Access3Share REQUIRED cdeps timing share nuopc_cap_share) 
   if(NOT TARGET ESMF::ESMF) #Access3Share probably already has ESMF with PUBLIC interface
     find_package(ESMF 8.3.0 MODULE REQUIRED)
@@ -104,7 +104,7 @@ if(NOT TARGET NetCDF::NetCDF_Fortran) #Access3Share probably already has NetCDF 
   find_package(NetCDF 4.7.3 MODULE REQUIRED Fortran)
 endif()
 
-if(OPENMP)
+if(WW3_OPENMP)
   find_package(OpenMP REQUIRED COMPONENTS Fortran)
 endif()
 
@@ -126,7 +126,7 @@ set_property(SOURCE ${SRC}/w3initmd.F90
 )
 target_link_libraries(ww3lib PUBLIC NetCDF::NetCDF_Fortran)
 
-if(ACCESS3_WW3)
+if(WW3_ACCESS3)
   target_link_libraries(ww3lib PUBLIC ESMF::ESMF PIO::PIO_C)
 endif()
 
@@ -141,7 +141,7 @@ message(VERBOSE "WW3 switch files: ${switch_files}")
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/model/src/cmake/src_list.cmake)
 
-if(ACCESS3_WW3)
+if(WW3_ACCESS3)
   list(APPEND ftn_src ${nuopc_mesh_cap_src})
 endif()
 
@@ -156,7 +156,7 @@ target_sources(ww3lib PRIVATE ${srcfiles})
 ## Utilities
 # Always build utilities:
 set(utility_apps ww3_grid ww3_strt ww3_outf ww3_ounf ww3_ounp)
-if(NOT ACCESS3_WW3)
+if(NOT WW3_ACCESS3)
   # A generic WW3 "shell" for testing
   list(APPEND utility_apps ww3_shel)
 endif()
@@ -184,15 +184,15 @@ target_sources(ww3_ounf PRIVATE
 #]==============================================================================]
 
 ## Library
-if(ACCESS3_WW3)
+if(WW3_ACCESS3)
   set_target_properties(ww3lib PROPERTIES
     OUTPUT_NAME access-ww3lib
     EXPORT_NAME ww3lib
   )
   install(TARGETS ww3lib
     EXPORT Ww3libTargets
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessWW3Cmeps_RunTime NAMELINK_COMPONENT AccessWW3Cmeps_Development
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessWW3Cmeps_Development
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessWW3_RunTime NAMELINK_COMPONENT AccessWW3_Development
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessWW3_Development
   )
   # Fortran module files are a special case, as currently there is no standard
   # way of handling them in CMake
@@ -200,7 +200,7 @@ if(ACCESS3_WW3)
   get_target_property(ww3_moddir ww3lib Fortran_MODULE_DIRECTORY)
   install(FILES ${ww3_moddir}/wav_comp_nuopc.mod
     DESTINATION ${CMAKE_INSTALL_MODULEDIR}/access-ww3
-    COMPONENT AccessWW3Cmeps_Development
+    COMPONENT AccessWW3_Development
   )
   install(EXPORT Ww3libTargets
     FILE Ww3libTargets.cmake
@@ -216,7 +216,7 @@ if(ACCESS3_WW3)
   )
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Ww3libConfig.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Ww3lib
-    COMPONENT AccessWW3Cmeps_Development 
+    COMPONENT AccessWW3_Development 
   )
 endif()
 

--- a/cmake/Access3Ww3libConfig.cmake.in
+++ b/cmake/Access3Ww3libConfig.cmake.in
@@ -1,0 +1,12 @@
+@PACKAGE_INIT@
+
+# Request components
+set(_required_components ${Ww3lib_FIND_COMPONENTS})
+
+# Run the normal Targets.cmake
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+include("${CMAKE_CURRENT_LIST_DIR}/Ww3libTargets.cmake")
+list(REMOVE_ITEM CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+
+# Check the requested components are valid
+check_required_components(_required_components)

--- a/cmake/Access3Ww3libConfig.cmake.in
+++ b/cmake/Access3Ww3libConfig.cmake.in
@@ -1,5 +1,9 @@
 @PACKAGE_INIT@
 
+if(@OPENMP@)
+  find_package(OpenMP REQUIRED)
+endif()
+
 # Request components
 set(_required_components ${Ww3lib_FIND_COMPONENTS})
 

--- a/cmake/Access3Ww3libConfig.cmake.in
+++ b/cmake/Access3Ww3libConfig.cmake.in
@@ -1,3 +1,5 @@
+# Copyright ACCESS-NRI and contributors. See the top-level LICENSE file for details.
+
 @PACKAGE_INIT@
 
 if(@OPENMP@)

--- a/cmake/FindESMF.cmake
+++ b/cmake/FindESMF.cmake
@@ -1,34 +1,81 @@
+# Earth System Modeling Framework
+
+# Copyright (c) 2002-2025 University Corporation for Atmospheric Research,
+# Massachusetts Institute of Technology, Geophysical Fluid Dynamics Laboratory,
+# University of Michigan, National Centers for Environmental Prediction,
+# Los Alamos National Laboratory, Argonne National Laboratory,
+# NASA Goddard Space Flight Center.
+# All rights reserved.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal with the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#   1. Redistributions of source code must retain the above copyright notice,
+#      this list of conditions and the following disclaimers.
+#   2. Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimers in the
+#      documentation and/or other materials provided with the distribution.
+#   3. Neither the names of the organizations developing this software, nor
+#      the names of its contributors may be used to endorse or promote products
+#      derived from this Software without specific prior written permission.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# WITH THE SOFTWARE.
+
 # - Try to find ESMF
 #
-# Requires setting ESMFMKFILE to the filepath of esmf.mk. If this is NOT set,
-# then ESMF_FOUND will always be FALSE. If ESMFMKFILE exists, then ESMF_FOUND=TRUE
-# and all ESMF makefile variables will be set in the global scope. Optionally,
-# set ESMF_MKGLOBALS to a string list to filter makefile variables. For example,
-# to globally scope only ESMF_LIBSDIR and ESMF_APPSDIR variables, use this CMake
-# command in CMakeLists.txt:
+# Uses ESMFMKFILE to find the filepath of esmf.mk. If this is NOT set, then this
+# module will attempt to find esmf.mk. If ESMFMKFILE exists, then
+# ESMF_FOUND=TRUE and all ESMF makefile variables will be set in the global
+# scope. Optionally, set ESMF_MKGLOBALS to a string list to filter makefile
+# variables. For example, to globally scope only ESMF_LIBSDIR and ESMF_APPSDIR
+# variables, use this CMake command in CMakeLists.txt:
 #
 #   set(ESMF_MKGLOBALS "LIBSDIR" "APPSDIR")
 
+# Set ESMFMKFILE as defined by system env variable. If it's not explicitly set
+# try to find esmf.mk file in default locations (ESMF_ROOT, CMAKE_PREFIX_PATH,
+# etc)
 
-# Add the ESMFMKFILE path to the cache if defined as system env variable
-if(DEFINED ENV{ESMFMKFILE} AND NOT DEFINED ESMFMKFILE)
-  set(ESMFMKFILE $ENV{ESMFMKFILE} CACHE FILEPATH "Path to ESMF mk file")
-endif()
+# - Common Usage
+#
+# Where to look for this FindESMF.cmake file
+#   list(APPEND CMAKE_MODULE_PATH "<PATH_TO_THIS_FILE>")
+#   <PATH_TO_THIS_FILE> is to be replaced with the directory for this file
+#
+# How to locate ESMF libraries and create target
+#   find_package(ESMF <X.Y.Z> MODULE REQUIRED)
+#   <X.Y.Z> is to be replaced with the minimum version required
+#
+# How to link targets
+#   target_link_libraries(<CMAKE_TARGET> PUBLIC ESMF::ESMF)
+#   <CMAKE_TARGET> is to be replaced with your CMake target
 
-# If it's not explicitly set try to find esmf.mk file in default locations (ESMF_ROOT, CMAKE_PREFIX_PATH, etc)
 if(NOT DEFINED ESMFMKFILE)
-  find_path(ESMFMKFILE_PATH esmf.mk PATH_SUFFIXES lib lib64)
-  if(ESMFMKFILE_PATH)
-    set(ESMFMKFILE ${ESMFMKFILE_PATH}/esmf.mk)
-    message(STATUS "Found esmf.mk file ${ESMFMKFILE}")
+  if(NOT DEFINED ENV{ESMFMKFILE})
+    find_path(ESMFMKFILE_PATH esmf.mk PATH_SUFFIXES lib lib64)
+    if(ESMFMKFILE_PATH)
+      set(ESMFMKFILE ${ESMFMKFILE_PATH}/esmf.mk)
+      message(STATUS "Found esmf.mk file ${ESMFMKFILE}")
+    endif()
   else()
-    message(STATUS "ESMFMKFILE not defined. This is the path to esmf.mk file. \
-Without this filepath, ESMF_FOUND will always be FALSE.")
+    set(ESMFMKFILE $ENV{ESMFMKFILE})
   endif()
 endif()
 
 # Only parse the mk file if it is found
 if(EXISTS ${ESMFMKFILE})
+  set(ESMFMKFILE ${ESMFMKFILE} CACHE FILEPATH "Path to esmf.mk file")
+  set(ESMF_FOUND TRUE CACHE BOOL "esmf.mk file found" FORCE)
+
   # Read the mk file
   file(STRINGS "${ESMFMKFILE}" esmfmkfile_contents)
   # Parse each line in the mk file
@@ -78,58 +125,70 @@ if(EXISTS ${ESMFMKFILE})
   set(ESMF_BETA_RELEASE FALSE)
   if(ESMF_VERSION_BETASNAPSHOT MATCHES "^('T')$")
     set(ESMF_BETA_RELEASE TRUE)
-    string(REGEX REPLACE ".*beta_snapshot_*\([0-9]*\).*" "\\1" ESMF_BETA_SNAPSHOT "${ESMF_VERSION_STRING_GIT}")
-    message(STATUS "Detected ESMF Beta snapshot ${ESMF_BETA_SNAPSHOT}")
+    if(ESMF_VERSION_STRING_GIT MATCHES "^ESMF.*beta_snapshot")
+      set(ESMF_BETA_SNAPSHOT ${ESMF_VERSION_STRING_GIT})
+    elseif(ESMF_VERSION_STRING_GIT MATCHES "^v.\..\..b")
+      set(ESMF_BETA_SNAPSHOT ${ESMF_VERSION_STRING_GIT})
+    else()
+      set(ESMF_BETA_SNAPSHOT 0)
+    endif()
+    message(STATUS "Detected ESMF Beta snapshot: ${ESMF_BETA_SNAPSHOT}")
   endif()
   set(ESMF_VERSION "${ESMF_VERSION_MAJOR}.${ESMF_VERSION_MINOR}.${ESMF_VERSION_PATCH}")
 
-  separate_arguments(ESMF_F90COMPILEPATHS NATIVE_COMMAND ${ESMF_F90COMPILEPATHS})
-  foreach(ITEM ${ESMF_F90COMPILEPATHS})
-     string(REGEX REPLACE "^-I" "" ITEM "${ITEM}")
-     list(APPEND tmp ${ITEM})
-  endforeach()
-  set(ESMF_F90COMPILEPATHS ${tmp})
-
-  # Look for static library, if not found try dynamic library
-  find_library(esmf_lib NAMES libesmf.a PATHS ${ESMF_LIBSDIR})
-  if(esmf_lib MATCHES "esmf_lib-NOTFOUND")
-    unset(esmf_lib)
-    message(STATUS "Static ESMF library not found, searching for dynamic library instead")
-    find_library(esmf_lib NAMES esmf_fullylinked libesmf.so PATHS ${ESMF_LIBSDIR})
-    if(esmf_lib MATCHES "esmf_lib-NOTFOUND")
-      unset(esmf_lib)
-      message(STATUS "Neither the dynamic nor the static ESMF library was found")
-    else()
-      set(_library_type SHARED)
+  # Find the ESMF library
+  if(USE_ESMF_STATIC_LIBS)
+    find_library(ESMF_LIBRARY_LOCATION NAMES libesmf.a PATHS ${ESMF_LIBSDIR} NO_DEFAULT_PATH)
+    if(ESMF_LIBRARY_LOCATION MATCHES "ESMF_LIBRARY_LOCATION-NOTFOUND")
+      message(WARNING "Static ESMF library (libesmf.a) not found in \
+                       ${ESMF_LIBSDIR}. Try setting USE_ESMF_STATIC_LIBS=OFF")
+    endif()
+    if(NOT TARGET ESMF::ESMF)
+      add_library(ESMF::ESMF STATIC IMPORTED)
     endif()
   else()
-    set(_library_type STATIC)
+    find_library(ESMF_LIBRARY_LOCATION NAMES esmf PATHS ${ESMF_LIBSDIR} NO_DEFAULT_PATH)
+    if(ESMF_LIBRARY_LOCATION MATCHES "ESMF_LIBRARY_LOCATION-NOTFOUND")
+      message(WARNING "ESMF library not found in ${ESMF_LIBSDIR}.")
+    endif()
+    if(NOT TARGET ESMF::ESMF)
+      add_library(ESMF::ESMF UNKNOWN IMPORTED)
+    endif()
   endif()
 
-  string(STRIP "${ESMF_F90ESMFLINKRPATHS} ${ESMF_F90ESMFLINKPATHS} ${ESMF_F90LINKPATHS} ${ESMF_F90LINKLIBS} ${ESMF_F90LINKOPTS}" ESMF_INTERFACE_LINK_LIBRARIES)
-  set(ESMF_LIBRARY_LOCATION ${esmf_lib})
+  # Add ESMF as an alias to ESMF::ESMF for backward compatibility
+  if(NOT TARGET ESMF)
+    add_library(ESMF ALIAS ESMF::ESMF)
+  endif()
+
+  # Add ESMF include directories
+  set(ESMF_INCLUDE_DIRECTORIES "")
+  separate_arguments(_ESMF_F90COMPILEPATHS UNIX_COMMAND ${ESMF_F90COMPILEPATHS})
+  foreach(_ITEM ${_ESMF_F90COMPILEPATHS})
+    string(REGEX REPLACE "^-I" "" _ITEM "${_ITEM}")
+    list(APPEND ESMF_INCLUDE_DIRECTORIES ${_ITEM})
+  endforeach()
+
+  # Add ESMF link libraries
+  string(STRIP "${ESMF_F90LINKRPATHS} ${ESMF_F90ESMFLINKRPATHS} ${ESMF_F90ESMFLINKPATHS} ${ESMF_F90LINKPATHS} ${ESMF_F90LINKLIBS} ${ESMF_F90LINKOPTS}" ESMF_INTERFACE_LINK_LIBRARIES)
+
+  # Finalize find_package
+  include(FindPackageHandleStandardArgs)
+
+  find_package_handle_standard_args(
+        ${CMAKE_FIND_PACKAGE_NAME}
+        REQUIRED_VARS ESMF_LIBRARY_LOCATION
+                      ESMF_INTERFACE_LINK_LIBRARIES
+                      ESMF_F90COMPILEPATHS
+        VERSION_VAR ESMF_VERSION)
+
+  set_target_properties(ESMF::ESMF PROPERTIES
+        IMPORTED_LOCATION "${ESMF_LIBRARY_LOCATION}"
+        INTERFACE_INCLUDE_DIRECTORIES "${ESMF_INCLUDE_DIRECTORIES}"
+        INTERFACE_LINK_LIBRARIES "${ESMF_INTERFACE_LINK_LIBRARIES}")
 
 else()
-
-  message(WARNING "ESMFMKFILE ${ESMFMKFILE} does not exist")
-
-endif()
-
-## Finalize find_package
-include(FindPackageHandleStandardArgs)
-
-find_package_handle_standard_args(
-    ${CMAKE_FIND_PACKAGE_NAME}
-    REQUIRED_VARS ESMF_LIBRARY_LOCATION
-                  ESMF_INTERFACE_LINK_LIBRARIES
-                  ESMF_F90COMPILEPATHS
-    VERSION_VAR ESMF_VERSION)
-
-## If ESMF is found create imported library target
-if(ESMF_FOUND)
-  add_library(esmf ${_library_type} IMPORTED)
-  set_target_properties(esmf PROPERTIES
-    IMPORTED_LOCATION "${ESMF_LIBRARY_LOCATION}"
-    INTERFACE_INCLUDE_DIRECTORIES "${ESMF_F90COMPILEPATHS}"
-    INTERFACE_LINK_LIBRARIES "${ESMF_INTERFACE_LINK_LIBRARIES}")
+  set(ESMF_FOUND FALSE CACHE BOOL "esmf.mk file NOT found" FORCE)
+  message(WARNING "ESMFMKFILE ${ESMFMKFILE} not found. Try setting ESMFMKFILE \
+                   to esmf.mk location.")
 endif()

--- a/cmake/FortranLib.cmake
+++ b/cmake/FortranLib.cmake
@@ -1,0 +1,8 @@
+function(add_fortran_library LIB MOD_DIR)
+    add_library(${LIB} ${ARGN})
+
+    get_target_property(LIB_DIR ${LIB} BINARY_DIR)
+    set_target_properties(${LIB} PROPERTIES Fortran_MODULE_DIRECTORY ${LIB_DIR}/${MOD_DIR})
+
+    target_include_directories(${LIB} INTERFACE "$<BUILD_INTERFACE:${LIB_DIR}/${MOD_DIR}>")
+  endfunction(add_fortran_library)

--- a/cmake/FortranLib.cmake
+++ b/cmake/FortranLib.cmake
@@ -1,3 +1,5 @@
+# Copyright ACCESS-NRI and contributors. See the top-level LICENSE file for details.
+
 function(add_fortran_library LIB MOD_DIR)
     add_library(${LIB} ${ARGN})
 

--- a/model/src/cmake/check_switches.cmake
+++ b/model/src/cmake/check_switches.cmake
@@ -1,6 +1,6 @@
 function(check_switches switches switch_files)
   # Read JSON file
-  file(READ ${CMAKE_CURRENT_SOURCE_DIR}/cmake/switches.json json_str)
+  file(READ ${CMAKE_CURRENT_SOURCE_DIR}/model/src/cmake/switches.json json_str)
   # Get length of top-level array of all switch categories
   string(JSON len LENGTH ${json_str})
   # CMake's foreach RANGE is inclusive, so subtract 1 when looping

--- a/model/src/w3srcemd.F90
+++ b/model/src/w3srcemd.F90
@@ -2088,7 +2088,7 @@ CONTAINS
 #ifdef W3_IC3
       CALL W3SIC3 ( SPEC,DEPTH, CG1,  WN1, IX, IY, VSIC, VDIC )
 #endif
-#ifndef W3_IC4_NUMERICS
+#if defined(W3_IC4) && !defined(W3_IC4_NUMERICS)
       CALL W3SIC4 ( SPEC,DEPTH, CG1,       IX, IY, VSIC, VDIC )
 #endif
 #ifdef W3_IC5
@@ -2119,7 +2119,7 @@ CONTAINS
 #ifdef W3_IC3
         ATT=EXP(ICE*VDIC(IS)*DTG)
 #endif
-#ifndef W3_IC4_NUMERICS
+#if defined(W3_IC4) && !defined(W3_IC4_NUMERICS)
        ATT=EXP(ICE*VDIC(IS)*DTG)
 #endif
 #ifdef W3_IC5


### PR DESCRIPTION
This changes the CMake build in WW3 to support ACCESS-OM3. It includes the patches from https://github.com/COSIMA/access-om3/tree/main/WW3/patches.

There is a [library build ](https://github.com/ACCESS-NRI/ACCESS-OM3/pull/35) and a standalone build which adds the [ww3_shel executable](https://github.com/ACCESS-NRI/ACCESS-OM3/pull/66)

All the WW3 forks are a mess, so i just overwrote the CMakeLists.txt file. We could change it in the future to have a seperate CMakeLists.txt file for access if needed.

general FYI @chrisb13 @ezhilsabareesh8 @dougiesquire 

Closes #1