### PR TITLE
Fix history files out sync with model components

### DIFF
--- a/model/src/wav_comp_nuopc.F90
+++ b/model/src/wav_comp_nuopc.F90
@@ -622,7 +622,7 @@ contains
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     endif
     ! Determine time attributes for history output
-    call ESMF_TimeGet( esmfTime, timeString=time_origin, calendar=calendar, rc=rc )
+    call ESMF_TimeGet( startTime, timeString=time_origin, calendar=calendar, rc=rc )
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     time_origin = 'seconds since '//time_origin(1:10)//' '//time_origin(12:19)
     !call ESMF_ClockGet(clock, calendar=calendar)


### PR DESCRIPTION
# Pull Request Summary

This PR fixes a WW3 output-time inconsistency where the timestamps in WW3 history NetCDF files drifted from the coupled model “true” time after restarts (e.g., monthly or annual restarts), leading to apparent time jumps when reading the history files.

Issue addressed: [iss831](https://github.com/ACCESS-NRI/access-om3-configs/issues/831)