### PR TITLE
Remove W3_IS2 compile guard from IC5 floe diameter update in w3wavemd

### DIFF
--- a/model/src/w3wavemd.F90
+++ b/model/src/w3wavemd.F90
@@ -880,7 +880,6 @@ CONTAINS
     !
     ! 1.e Ice floe interval
     !
-#ifdef W3_IS2
     IF ( FLIC5 ) THEN
       IF ( TIC5(1) .GE. 0 ) THEN
         DTI50   = DSEC21 ( TIC5 , TI5 )
@@ -897,7 +896,6 @@ CONTAINS
     ELSE
       DTI50   = 0.
     END IF
-#endif
     !
     ! 2.  Determine next time from ending and output --------------------- /
     !     time and get corresponding time step.
@@ -1314,7 +1312,6 @@ CONTAINS
         !
         ! 3.3.3 Update ice floe diameter
         !
-#ifdef W3_IS2
         IF ( FLIC5 .AND. DTI50.NE.0. ) THEN
           !
           IF ( TIC5(1).GE.0 ) THEN
@@ -1336,7 +1333,6 @@ CONTAINS
           END IF
           !
         END IF
-#endif
         call print_memcheck(memunit, 'memcheck_____:'//' WW3_WAVE TIME LOOP 11a')
         !
         ! 3.4 Transform grid (if new water level).
@@ -2881,10 +2877,8 @@ CONTAINS
          '     NEW ATM MOMENTUM BEFORE OLD ATM MOMENTUM '/)
 1008 FORMAT (/' *** WAVEWATCH III ERROR IN W3WAVE :'/                    &
          '     NEW AIR DENSITY BEFORE OLD AIR DENSITY '/)
-#ifdef W3_IS2
 1006 FORMAT (/' *** WAVEWATCH III ERROR IN W3WAVE :'/                    &
          '     NEW IC5 FIELD BEFORE OLD IC5 FIELD '/)
-#endif
 1030 FORMAT (/' *** WAVEWATCH III WARING IN W3WAVE :'/                   &
          '     AT LEAST ONE PROCESSOR HAS 0 ACTIVE POINTS',              &
          ' IN GRID',I3)


### PR DESCRIPTION
This PR fixes the missing `W3UIC5` update in IC4 builds by removing incorrect `#ifdef W3_IS2` guards in `w3wavemd.F90`.

In ACCESS-OM3 `IC4 IS0` configurations, CICE correctly exports floe diameter as `Si_floediam`, and WW3 imports it into `ICEP5`, but the `W3UIC5` call that copies `ICEP5` into `ICEF` was not compiled because `W3_IS2` is not defined. As a result, `ICEF` stayed at its hard-coded initial value of 1000 m throughout the run.

The fix removes the unnecessary compile guards while keeping the existing runtime check, refer [here](https://github.com/ACCESS-NRI/WW3/blob/1845b8c17321e8625829f8edad763f44722cfeac/model/src/w3wavemd.F90#L1315-L1318):

```fortran
IF ( FLIC5 .AND. DTI50.NE.0. ) THEN
  CALL W3UIC5( FLFRST )
END IF
```

Validation with [`access-om3/pr242-1`](https://github.com/ACCESS-NRI/ACCESS-OM3/pull/242) confirms the fix: `ICEF` is no longer constant 1000 m, but varies from the CICE FSD floor value of 5.4 m up to ~1255 m, consistent with `2 × fsdrad`.

This restores the intended CICE → CMEPS → WW3 floe-diameter coupling path for IC4 wave-ice scattering.

<p class="isSelectedEnd"><span>The fixed build produces spatially varying </span><code dir="ltr"><span>ICEF</span></code><span> values instead of the constant 1000 m initialisation value:</span></p>

Day | Ice cells | ICEF min | ICEF mean | ICEF max
-- | -- | -- | -- | --
2 Jan 1958 | 7,907 | 5.4 m | 20.8 m | 830.8 m
3 Jan 1958 | 8,174 | 5.4 m | 41.3 m | 839.8 m
4 Jan 1958 | 8,356 | 5.4 m | 62.0 m | 1101.6 m
5 Jan 1958 | 8,478 | 5.4 m | 75.3 m | 1239.9 m
6 Jan 1958 | 8,534 | 5.4 m | 84.9 m | 1255.2 m
Buggy build | 17,016 | 1000.0 m | 1000.0 m | 1000.0 m

